### PR TITLE
[MAIN-152] add global linting CI check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: lint-backend
+      - name: lint
         run: |
           npm ci
           npx lerna bootstrap
           npx lerna run lint
+          npx lerna run lint:fix

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: lint
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: lint-backend
+        run: |
+          npm ci
+          npx lerna bootstrap
+          npx lerna run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,5 @@ jobs:
         run: |
           npm ci
           npx lerna bootstrap
-          npx lerna run lint
-          npx lerna run lint:fix
+          npx lerna run lint --parallel
+          npx lerna run lint:fix --parallel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - name: lint
+      - name: install and setup the monorepo dependencies
         run: |
           npm ci
           npx lerna bootstrap
-          npx lerna run lint --parallel
-          npx lerna run lint:fix --parallel
+      - name: all packages need to have lint script defined in package.json
+        run: ./bin/every-package-json.sh ".scripts.lint != null"
+      - name: all packages need to have lint:fix script defined in package.json
+        run: ./bin/every-package-json.sh '.scripts."lint:fix" != null'
+      - name: checking if packages are formatted properly (lint)
+        run: npx lerna run lint --parallel
+      - name: checking if packages can be auto formatted (lint:fix)
+        run: npx lerna run lint:fix --parallel

--- a/bin/every-package-json.sh
+++ b/bin/every-package-json.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Takes jq filter that acts like a predicate function and exits non-zero if any package.json does not result in "true" for that jq filter.
+# We can use this to run checks on all packages in our monorepo.
+
+# Examples:
+#
+# Exit non-zero if any packages don't have the lint script defined
+# ./every-package-json.sh ".script.lint == null"
+# 
+# Exit non-zero if any packages have over 10 scripts defined
+# ./every-package-json.sh ".script | length >= 10"
+
+JQ_FILTER=$1
+
+for package in $(npx lerna list -l -a --ndjson --loglevel error | jq -r .location)
+do
+  if [[ $(jq "${JQ_FILTER}" < "${package}/package.json") != "true" ]]
+  then
+    echo "ERROR: Packege ${package} has an invalid package.json file which failed the json filter: ${JQ_FILTER}"
+    exit 1
+  fi
+done 
+
+exit 0

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,9 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "lint": "echo no good way to lint docusaurus repo, check: https://github.com/facebook/docusaurus/issues/2965",
+    "lint:fix": "echo no good way to lint docusaurus repo, check: https://github.com/facebook/docusaurus/issues/2965"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18200,7 +18200,10 @@
         "cross-env": "^7.0.3"
       },
       "devDependencies": {
-        "concurrently": "^7.1.0"
+        "concurrently": "^7.1.0",
+        "eslint": "^8.21.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-plugin-import": "^2.26.0"
       }
     }
   },
@@ -21561,7 +21564,10 @@
       "requires": {
         "@urturn/runner": "0.1.0",
         "concurrently": "^7.1.0",
-        "cross-env": "^7.0.3"
+        "cross-env": "^7.0.3",
+        "eslint": "^8.21.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-plugin-import": "^2.26.0"
       }
     },
     "@webassemblyjs/ast": {

--- a/packages/runner/frontend/package.json
+++ b/packages/runner/frontend/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "start": "react-scripts start",
     "lint": "eslint . --ignore-path .gitignore --ext .js,.jsx",
+    "lint:fix": "eslint . --ignore-path .gitignore --ext .js,.jsx --fix",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "runner",
     "prepare": "cd frontend && npm install",
-    "lint": "eslint . --ignore-path .gitignore --ext .js",
+    "lint": "eslint . --ignore-path .gitignore --ext .js && cd frontend && npm run lint",
+    "lint:fix": "eslint . --ignore-path .gitignore --ext .js --fix && cd frontend && npm run lint:fix",
     "build": "cd frontend && npm run build"
   },
   "repository": {

--- a/packages/test-app/.eslintrc.cjs
+++ b/packages/test-app/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  ignorePatterns: [
+    'frontend', // frontend folder has it's own eslint config
+  ],
+  env: {
+    es2021: true,
+    node: true,
+  },
+  extends: [
+    'airbnb-base',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {
+    'import/extensions': 'off',
+  },
+};

--- a/packages/test-app/.gitignore
+++ b/packages/test-app/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/test-app/frontend/package.json
+++ b/packages/test-app/frontend/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "react-scripts start",
     "lint": "eslint . --ignore-path .gitignore --ext .js,.jsx",
+    "lint:fix": "eslint . --ignore-path .gitignore --ext .js,.jsx --fix",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -10,7 +10,7 @@
     "dev": "concurrently \"npm run dev:runner\" \"npm run dev:frontend\"",
     "dev:runner": "runner --frontend-port 3000 --disable-open --debug --dev",
     "dev:frontend": "cd frontend && cross-env BROWSER=none PORT=3000 npm start",
-    "lint": "eslint . --ignore-path .gitignore --ext .js && cd frontend && npm run lint",
+    "lint:fix": "eslint . --ignore-path .gitignore --ext .js --fix && cd frontend && npm run lint:fix",
     "postinstall": "cd frontend && npm install"
   },
   "author": "",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -11,7 +11,6 @@
     "dev:runner": "runner --frontend-port 3000 --disable-open --debug --dev",
     "dev:frontend": "cd frontend && cross-env BROWSER=none PORT=3000 npm start",
     "lint": "eslint . --ignore-path .gitignore --ext .js && cd frontend && npm run lint",
-    "lint:fix": "eslint . --ignore-path .gitignore --ext .js --fix && cd frontend && npm run lint:fix",
     "postinstall": "cd frontend && npm install"
   },
   "author": "",

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -10,8 +10,8 @@
     "dev": "concurrently \"npm run dev:runner\" \"npm run dev:frontend\"",
     "dev:runner": "runner --frontend-port 3000 --disable-open --debug --dev",
     "dev:frontend": "cd frontend && cross-env BROWSER=none PORT=3000 npm start",
-    "lint": "eslint . --ignore-path .gitignore --ext .js",
-    "lint:fix": "eslint . --ignore-path .gitignore --ext .js --fix",
+    "lint": "eslint . --ignore-path .gitignore --ext .js && cd frontend && npm run lint",
+    "lint:fix": "eslint . --ignore-path .gitignore --ext .js --fix && cd frontend && npm run lint:fix",
     "postinstall": "cd frontend && npm install"
   },
   "author": "",
@@ -21,6 +21,9 @@
     "cross-env": "^7.0.3"
   },
   "devDependencies": {
-    "concurrently": "^7.1.0"
+    "concurrently": "^7.1.0",
+    "eslint": "^8.21.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-plugin-import": "^2.26.0"
   }  
 }

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -10,6 +10,7 @@
     "dev": "concurrently \"npm run dev:runner\" \"npm run dev:frontend\"",
     "dev:runner": "runner --frontend-port 3000 --disable-open --debug --dev",
     "dev:frontend": "cd frontend && cross-env BROWSER=none PORT=3000 npm start",
+    "lint": "eslint . --ignore-path .gitignore --ext .js && cd frontend && npm run lint",
     "lint:fix": "eslint . --ignore-path .gitignore --ext .js --fix && cd frontend && npm run lint:fix",
     "postinstall": "cd frontend && npm install"
   },


### PR DESCRIPTION
Setup global linting CI check which does several things:
1. runs `npm run lint` for all packages
2. runs `npm run lint:fix` for all packages

both of these commands must exit successfully. If any of the commands fail then that indicates either the package was not set up properly OR that it is improperly formatted. We want every package to have the `npm run lint:fix` defined so non-vscode users can have an auto fix strategy (e.g. `vim`) that doesn't rely on the vscode eslint plugin. However, it will always be strongly recommended to use VScode as all other IDEs will be second class