### PR TITLE
[MAIN-337] Add Readme for instructions on adding templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ https://docs.urturn.app/
 
 Talk to us on [discord](https://discord.gg/myWacjdb5S)
 
-## Misc
-
-contributor [docs](https://docs.google.com/document/d/1C5VCiNZEYpNmNItgmS53FOrZrA--SPJt-oCrYwC_kEU/edit?usp=sharing)
+## Contributors
 
 ![Alt](https://repobeats.axiom.co/api/embed/1d535cc9b3dda15020410a5fa918edab884816d5.svg)
+
+### Contributing Instructions
+
+- Adding and modifying templates [readme](templates/README.md)
+- Internal Contributor [docs](https://docs.google.com/document/d/1C5VCiNZEYpNmNItgmS53FOrZrA--SPJt-oCrYwC_kEU/edit?usp=sharing)

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,38 @@
+# Adding/Modifying Templates
+
+## Before you start
+
+- Discuss with maintainers and other developers who use your framework in our [Discord](https://discord.gg/myWacjdb5S)
+- Raise a [GitHub issue](https://github.com/turnbasedgames/urturn/issues) to open up discussion (make sure one doesn't already exist); maintainers should give you the green/red light in a timely manner.
+
+## Local Development
+
+After cloning the monorepo, install dependencies, link packages, and build:
+
+```bash
+$ npm i # install all dependencies
+$ npx lerna boostrap --hoist # link all packages together
+$ npx lerna run build # builds all packages
+```
+
+You will mainly be working with the `@urturn/runner` package under `packages/runner` and the template under `templates/template-<framework>`. Refer to other templates to see what you have to change.
+
+Testing your changes with the runner:
+
+```bash
+$ npx lerna @urturn/runner init my-game --git-url <url of your fork> --commit <your branch>
+```
+
+**Warning** - the flags `git-url` and `commit` are hidden because these are only used for testing the runner, so you won't see these if you add the help flag, `-h`, to your command
+
+## Crediting Contributors
+
+If you create a template, we add your github username to the prompt. For example:
+
+```bash
+$ npx  @urturn/runner init my-game 
+@urturn/runner v0.1.12
+? Which game frontend do you want to use?
+❯ ReactJS (Created by @kevo1ution) # <== your GH username
+  None 
+```

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,7 +2,7 @@
 
 ## Before you start
 
-- Discuss with maintainers and other developers who use your framework in our [Discord](https://discord.gg/myWacjdb5S)
+- Discuss with maintainers and other game developers in our [Discord](https://discord.gg/myWacjdb5S)
 - Raise a [GitHub issue](https://github.com/turnbasedgames/urturn/issues) to open up discussion (make sure one doesn't already exist); maintainers should give you the green/red light in a timely manner.
 
 ## Local Development

--- a/templates/README.md
+++ b/templates/README.md
@@ -20,7 +20,7 @@ You will mainly be working with the `@urturn/runner` package under `packages/run
 Testing your changes with the runner:
 
 ```bash
-$ npx lerna @urturn/runner init my-game --git-url <url of your fork> --commit <your branch>
+$ npx lerna @urturn/runner init my-game --git-url <url of your fork> --commit <specific commit or branch>
 ```
 
 **Warning** - the flags `git-url` and `commit` are hidden because these are only used for testing the runner, so you won't see these if you add the help flag, `-h`, to your command


### PR DESCRIPTION
**What**
- Adds new `--git-url` flag to the `runner init` sub command for testing with forks
- Adds `Readme.md` instructions for contributing templates

**Why**
- Help enable other contributors to easily add and modify their favorite templates #142 